### PR TITLE
Fix kind mismatch in calls to modulo

### DIFF
--- a/src/fhash_tbl.f90
+++ b/src/fhash_tbl.f90
@@ -130,7 +130,7 @@ subroutine fhash_tbl_unset(tbl,key,stat)
     return
   end if
 
-  index = modulo(key%hash(),size(tbl%buckets)) + 1
+  index = modulo(key%hash(),size(tbl%buckets,kind=int64)) + 1
   call sll_remove(tbl%buckets(index),key,found)
 
   if (present(stat)) stat = merge(0,FHASH_KEY_NOT_FOUND,found)
@@ -162,7 +162,7 @@ subroutine fhash_tbl_check_key(tbl,key,stat)
 
   stat = 0
 
-  index = modulo(key%hash(),size(tbl%buckets)) + 1
+  index = modulo(key%hash(),size(tbl%buckets,kind=int64)) + 1
 
   call sll_find_in(tbl%buckets(index),key,data,found)
 
@@ -242,7 +242,7 @@ subroutine fhash_tbl_set_scalar(tbl,key,value,pointer)
 
   if (.not.allocated(tbl%buckets)) call fhash_tbl_allocate(tbl)
 
-  index = modulo(key%hash(),size(tbl%buckets)) + 1
+  index = modulo(key%hash(),size(tbl%buckets,kind=int64)) + 1
 
   call sll_push_node(tbl%buckets(index),key,value,pointer)
 
@@ -295,7 +295,7 @@ subroutine fhash_tbl_get_data(tbl,key,data,stat)
 
   if (present(stat)) stat = 0
 
-  index = modulo(key%hash(),size(tbl%buckets)) + 1
+  index = modulo(key%hash(),size(tbl%buckets,kind=int64)) + 1
 
   call sll_find_in(tbl%buckets(index),key,data,found)
 


### PR DESCRIPTION
Per the Fortran standard, arguments to modulo must have the same type and kind. The output of the `size()` function was being passed to modulo without specifying the kind; this results in a mismatch between the two arguments unless the default integer kind happens to be the same kind as output from the `fhash_key_t%hash()` function passed in the first argument to modulo. This produced an error in a standard compliant compiler (or when the compiler is set to check for standard compliance).

This PR addresses this by specifying the kind output by size as `int64` to match the output from `fhash_key_t%hash()`. 

This fixes #16.