### PR TITLE
Major update: add iterator type, to_string method and CI updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,56 +3,49 @@ name: fpm test
 on: [push, pull_request]
 
 jobs:
-  gfortran-nix:
+  test:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        toolchain:
+          - {compiler: gcc, version: 10}
         include:
-        - os: ubuntu-latest
-          gcc_v: 9
-        - os: macos-latest
-          gcc_v: 9
-
-    env:
-      FC: gfortran
-      GCC_V: ${{ matrix.gcc_v }}
+          - os: ubuntu-latest
+            toolchain: {compiler: intel, version: '2023.1'}
+          - os: ubuntu-latest
+            toolchain: {compiler: gcc, version: 12}
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v1
+      - uses: awvwgk/setup-fortran@v1
+        id: setup-fortran
+        with:
+          compiler: ${{ matrix.toolchain.compiler }}
+          version: ${{ matrix.toolchain.version }}
 
-    - name: Install GFortran macOS
-      if: contains(matrix.os, 'macos')
-      run: |
-          ln -s /usr/local/bin/gfortran-${GCC_V} /usr/local/bin/gfortran
-          which gfortran-${GCC_V}
-          which gfortran
+      - run: ${{ env.FC }} --version
+        env:
+          FC: ${{ steps.setup-fortran.outputs.fc }}
+      
+      - name: Install fpm
+        uses: fortran-lang/setup-fpm@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Install GFortran Linux
-      if: contains(matrix.os, 'ubuntu')
-      run: |
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_V} 100 \
-        --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-${GCC_V} \
-        --slave /usr/bingcov gcov /usr/bin/gcov-${GCC_V}
+      - name: Checkout code
+        uses: actions/checkout@v1
 
-    - name: Install fpm
-      uses: fortran-lang/setup-fpm@v4
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run tests and demo programs (debug)
+        run: |
+          fpm test
+          fpm run *-demo
 
-    - name: Run tests and demo programs (debug)
-      run: |
-        gfortran --version
-        fpm test
-        fpm run *-demo
+      - name: Run tests and demo programs (release)
+        run: |
+          fpm test --profile release
+          fpm run *-demo --profile release
 
-    - name: Run tests and demo programs (release)
-      run: |
-        gfortran --version
-        fpm test --profile release
-        fpm run *-demo --profile release
 
   gfortran-windows-msys2-mingw64:
     runs-on: windows-latest
@@ -89,53 +82,3 @@ jobs:
         gfortran --version
         fpm test --profile release
         fpm run *-demo --profile release
-
-  Intel:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v1
-
-    - name: Install fpm
-      uses: fortran-lang/setup-fpm@v4
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Install ifort from cache
-      id: cache-oneapi
-      uses: actions/cache@v2
-      with:
-        path: |
-          /opt/intel/oneapi/compiler
-          /opt/intel/oneapi/setvars.sh
-        key: oneapi-cache-v0
-
-    - name: Install ifort with apt
-      if: steps.cache-oneapi.outputs.cache-hit != 'true'
-      run: |
-        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-        rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-        echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-        sudo apt-get update
-        sudo apt-get install intel-oneapi-ifort
-        sudo rm -rf /opt/intel/oneapi/compiler/latest/linux/lib/emu
-        sudo rm -rf /opt/intel/oneapi/compiler/latest/linux/lib/oclfpga
-
-    - name: Setup ifort env
-      run: |
-        source /opt/intel/oneapi/setvars.sh
-        printenv >> $GITHUB_ENV
-        
-    - name: Run tests and demo programs (debug)
-      run: |
-        ifort --version
-        fpm test --compiler ifort
-        fpm run *-demo --compiler ifort
-
-    - name: Run tests and demo programs (release)
-      run: |
-        ifort --version
-        fpm test --compiler ifort --profile release
-        fpm run *-demo --compiler ifort --profile release
-          

--- a/app/3-custom-key-demo/index.md
+++ b/app/3-custom-key-demo/index.md
@@ -6,9 +6,9 @@ title: Example: Custom key types
 
 Custom key types can be defined simply by extension of the abstract `fhash_key_t` type
 defined in [`fhash_key_base`](../../src/fhash_key/base.f90).
-Extensions of this type must implement the `equals` and `hash` procedures.
-Optionally, you may also override the `fhash_key` interface with a helper
-function to generate a key from your custom type.
+Extensions of this type must implement the `equals`, `hash` and `to_string` procedures.
+Optionally, you may also override the `fhash_key` interface with a helper function to
+generate a key from your custom type.
 
 To perform the hashing, the included `fhash_fnv` module provides the `fnv_1a` interface
 which supports default scalar characters and 32bit/64bit scalar/1D integers.

--- a/app/3-custom-key-demo/my_key_type.f90
+++ b/app/3-custom-key-demo/my_key_type.f90
@@ -29,6 +29,7 @@ module my_key_type
 
       procedure :: hash => key_hash_string_t
       procedure :: equals => key_equals_string_t
+      procedure, pass :: to_string => key_to_string
 
   end type key_string_t
 
@@ -93,6 +94,21 @@ contains
     end do
 
   end function key_hash_string_t
+
+
+  !> Generate string representation of hash
+  pure function key_to_string(key) result(str)
+    class(key_string_t), intent(in) :: key
+    character(:), allocatable :: str
+
+    integer :: i
+
+    str = ''
+    do i=1,size(key%value)
+      str = str//','//key%value(i)%s
+    end do
+
+  end function key_to_string
 
 
   !> Helper function to create new key container from

--- a/app/4-iter-demo/index.md
+++ b/app/4-iter-demo/index.md
@@ -1,0 +1,8 @@
+---
+title: Example: Iterating over hash table items
+---
+
+
+```fortran
+{!app/4-iter-demo/main.f90!}
+```

--- a/app/4-iter-demo/main.f90
+++ b/app/4-iter-demo/main.f90
@@ -1,0 +1,58 @@
+!> Example program demonstrating how to iterate over items in hash table
+program fhash_demo
+  use fhash, only: fhash_tbl_t, key=>fhash_key, fhash_iter_t, fhash_key_t
+  implicit none
+
+  type(fhash_tbl_t) :: tbl
+  type(fhash_iter_t) :: iter
+  class(fhash_key_t), allocatable :: ikey
+  class(*), allocatable :: idata
+  
+  print *, '# fhash demo program: iter-demo'
+  
+  call tbl%set(key('my_key_1'), value=10)
+  call tbl%set(key('my_key_2'), value=1.0)
+  call tbl%set(key(123456), value='a string value')
+  call tbl%set(key([1,2,3,4,5]), value=.false.)
+
+  !> Iterate over all items in table
+  iter = fhash_iter_t(tbl)
+  do while(iter%next(ikey,idata))
+
+    write(*,*) 'Key = "'//ikey%to_string()//'"'
+    
+    call print_polymorphic(idata)
+
+  end do
+
+! call iter%reset()  ! (Reset if iterator needed again)
+
+
+contains
+
+  !> Helper routine to print out polymorphic variable for intrinsics data types
+  subroutine print_polymorphic(data)
+    class(*), intent(in) :: data
+
+    select type(d=>data)
+
+    type is(integer)
+      write(*,*) d
+    
+    type is(real)
+      write(*,*) d
+
+    type is(character(*))
+      write(*,*) d
+
+    type is(logical)
+      write(*,*) d
+
+    class default
+      write(*,*) '[unknown data type, print not implemented]'
+
+    end select
+
+  end subroutine print_polymorphic
+
+end program fhash_demo

--- a/fpm.toml
+++ b/fpm.toml
@@ -30,3 +30,8 @@ name="benchmark"
 source-dir="app/3-custom-key-demo"
 main="main.f90"
 name="custom-key-demo"
+
+[[executable]]
+source-dir="app/4-iter-demo"
+main="main.f90"
+name="iter-demo"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(FHASH_SOURCES fhash.f90 fhash_sll.f90 fhash_data_container.f90 fhash_tbl.f90 fhash_fnv.f90 fhash_key/base.f90 fhash_key/int32.f90 fhash_key/int64.f90 fhash_key/char.f90 fhash_key/int32_1d.f90 fhash_key/int64_1d.f90)
+set(FHASH_SOURCES fhash.f90 fhash_sll.f90 fhash_data_container.f90 fhash_tbl.f90 fhash_tbl_iter.f90 fhash_fnv.f90 fhash_key/base.f90 fhash_key/int32.f90 fhash_key/int64.f90 fhash_key/char.f90 fhash_key/int32_1d.f90 fhash_key/int64_1d.f90)
 add_library(fhash SHARED  ${FHASH_SOURCES})
 target_include_directories(fhash PUBLIC
   $<BUILD_INTERFACE:${CMAKE_Fortran_MODULE_DIRECTORY}>

--- a/src/fhash.f90
+++ b/src/fhash.f90
@@ -1,5 +1,6 @@
 module fhash
 use fhash_tbl, only: fhash_tbl_t
+use fhash_tbl_iter, only: fhash_iter_t
 use fhash_key_base, only: fhash_key_t
 use fhash_key_char, only: fhash_key_char_t, fhash_key
 use fhash_key_int32, only: fhash_key_int32_t, fhash_key

--- a/src/fhash_data_container.f90
+++ b/src/fhash_data_container.f90
@@ -93,7 +93,7 @@ contains
 
     if (present(raw)) then
       if (present(match)) match = .true.
-      raw = data
+      allocate(raw, source=data)
     end if
 
     select type(d=>data)

--- a/src/fhash_key/base.f90
+++ b/src/fhash_key/base.f90
@@ -12,6 +12,7 @@ module fhash_key_base
   contains
     procedure(hash_proc), deferred :: hash
     procedure(equality_proc), deferred :: equals
+    procedure(to_string_proc), deferred :: to_string
     generic, public :: operator(==) => equals
   end type fhash_key_t
 
@@ -29,6 +30,12 @@ module fhash_key_base
       class(fhash_key_t), intent(in) :: key
       integer(int64) :: hash
     end function hash_proc
+
+     function to_string_proc(key) result(str)
+      import
+      class(fhash_key_t), intent(in) :: key
+      character(:), allocatable :: str
+    end function to_string_proc
 
   end interface
 

--- a/src/fhash_key/char.f90
+++ b/src/fhash_key/char.f90
@@ -17,6 +17,7 @@ module fhash_key_char
   contains
     procedure, pass :: hash => key_hash_char  
     procedure, pass :: equals => key_equal_char
+    procedure, pass :: to_string => key_char_to_string
   end type fhash_key_char_t
 
   interface fhash_key
@@ -55,6 +56,16 @@ module fhash_key_char
     hash = fnv_1a(key%value)
 
   end function key_hash_char
+
+
+  !> Generate string representation of hash
+   function key_char_to_string(key) result(str)
+    class(fhash_key_char_t), intent(in) :: key
+    character(:), allocatable :: str
+
+    str = key%value
+
+  end function key_char_to_string
 
 
   !> Create new key container from a scalar int32

--- a/src/fhash_key/int32.f90
+++ b/src/fhash_key/int32.f90
@@ -17,7 +17,8 @@ module fhash_key_int32
   contains
     procedure, pass :: hash => key_hash_int32  
     procedure, pass :: equals => key_equal_int32
-  end type fhash_key_int32_t
+    procedure, pass :: to_string => key_int32_to_string
+    end type fhash_key_int32_t
 
   interface fhash_key
     module procedure :: key_from_int32
@@ -53,6 +54,18 @@ contains
       hash = fnv_1a(key%value)
 
   end function key_hash_int32
+
+
+  !> Generate string representation of hash
+  pure function key_int32_to_string(key) result(str)
+    class(fhash_key_int32_t), intent(in) :: key
+    character(:), allocatable :: str
+
+    allocate(character(1024) :: str)
+    write(str,*) key%value
+    str = trim(str)
+
+  end function key_int32_to_string
 
 
   !> Create new key container from a scalar int32

--- a/src/fhash_key/int32_1d.f90
+++ b/src/fhash_key/int32_1d.f90
@@ -17,7 +17,8 @@ module fhash_key_int32_1d
   contains
     procedure, pass :: hash => key_hash_int32_1d  
     procedure, pass :: equals => key_equal_int32_1d
-  end type fhash_key_int32_1d_t
+    procedure, pass :: to_string => key_int32_1d_to_string
+    end type fhash_key_int32_1d_t
 
   interface fhash_key
     module procedure :: key_from_int32_1d
@@ -59,6 +60,18 @@ contains
       hash = fnv_1a(key%value)
 
   end function key_hash_int32_1d
+
+
+  !> Generate string representation of hash
+  pure function key_int32_1d_to_string(key) result(str)
+    class(fhash_key_int32_1d_t), intent(in) :: key
+    character(:), allocatable :: str
+
+    allocate(character(1024) :: str)
+    write(str,*) key%value
+    str = trim(str)
+
+  end function key_int32_1d_to_string
 
 
   !> Create new key container from a scalar int32

--- a/src/fhash_key/int64.f90
+++ b/src/fhash_key/int64.f90
@@ -17,7 +17,8 @@ module fhash_key_int64
   contains
     procedure, pass :: hash => key_hash_int64  
     procedure, pass :: equals => key_equal_int64
-  end type fhash_key_int64_t
+    procedure, pass :: to_string => key_int64_to_string
+    end type fhash_key_int64_t
 
   interface fhash_key
     module procedure :: key_from_int64
@@ -55,6 +56,18 @@ contains
   end function key_hash_int64
 
   
+  !> Generate string representation of hash
+  pure function key_int64_to_string(key) result(str)
+    class(fhash_key_int64_t), intent(in) :: key
+    character(:), allocatable :: str
+
+    allocate(character(1024) :: str)
+    write(str,*) key%value
+    str = trim(str)
+
+  end function key_int64_to_string
+
+
   !> Create new key container from a scalar int64
   function key_from_int64(source) result(key)
     integer(int64), intent(in) :: source

--- a/src/fhash_key/int64_1d.f90
+++ b/src/fhash_key/int64_1d.f90
@@ -17,7 +17,8 @@ module fhash_key_int64_1d
   contains
     procedure, pass :: hash => key_hash_int64_1d  
     procedure, pass :: equals => key_equal_int64_1d
-  end type fhash_key_int64_1d_t
+    procedure, pass :: to_string => key_int64_1d_to_string
+    end type fhash_key_int64_1d_t
 
   interface fhash_key
     module procedure :: key_from_int64_1d
@@ -59,6 +60,18 @@ contains
       hash = fnv_1a(key%value)
 
   end function key_hash_int64_1d
+
+
+  !> Generate string representation of hash
+  pure function key_int64_1d_to_string(key) result(str)
+    class(fhash_key_int64_1d_t), intent(in) :: key
+    character(:), allocatable :: str
+
+    allocate(character(1024) :: str)
+    write(str,*) key%value
+    str = trim(str)
+
+  end function key_int64_1d_to_string
 
 
   !> Create new key container from a scalar int64

--- a/src/fhash_sll.f90
+++ b/src/fhash_sll.f90
@@ -124,6 +124,49 @@ contains
   end subroutine sll_find_in
 
 
+  !> Return a node at a specific depth in the sll
+  recursive subroutine sll_get_at(node,depth,key,data,found)
+
+    !> Node to search in
+    type(fhash_node_t), intent(in), target :: node
+
+    !> Node depth to access
+    integer, intent(in) :: depth
+
+    !> Key of found item
+    !>  (Unallocated if no node is found at specified depth)
+    class(fhash_key_t), intent(out), allocatable :: key
+
+    !> Pointer to value container if found.
+    !> (Unassociated if no node is found at specified depth)
+    type(fhash_container_t), pointer, intent(out) :: data
+
+    logical, intent(out), optional :: found
+    
+    data => NULL()
+
+    if (present(found)) found = .false.
+
+    if (.not.allocated(node%key)) then
+
+      return
+
+    else if (depth == 1) then
+
+      if (present(found)) found = .true.
+      key = node%key
+      data => node%value
+      return
+
+    else if (associated(node%next)) then
+      
+      call sll_get_at(node%next,depth-1,key,data,found) 
+      
+    end if
+
+  end subroutine sll_get_at
+
+
   !> Search for a node with a specific key and remove
   recursive subroutine sll_remove(node,key,found,parent_node)
 

--- a/src/fhash_tbl_iter.f90
+++ b/src/fhash_tbl_iter.f90
@@ -8,6 +8,7 @@ module fhash_tbl_iter
   private
   public fhash_iter_t
 
+  !> Iterator type for iterating over hash table items
   type fhash_iter_t
 
     type(fhash_tbl_t), pointer :: tbl => NULL()
@@ -17,7 +18,9 @@ module fhash_tbl_iter
 
   contains
     procedure :: next => fhash_iter_next
+    procedure :: reset => fhash_iter_reset
   end type fhash_iter_t
+
 
   interface fhash_iter_t
     module procedure :: fhash_iter_init
@@ -25,6 +28,7 @@ module fhash_tbl_iter
 
   contains
 
+  !> Initialise fhash iterator
   function fhash_iter_init(tbl) result(iter)
     type(fhash_tbl_t), intent(in), target :: tbl
     type(fhash_iter_t) :: iter
@@ -33,7 +37,8 @@ module fhash_tbl_iter
 
   end function fhash_iter_init
 
-    
+  
+  !> Return next item from iterator
   function fhash_iter_next(iter,key,data) result(found)
     class(fhash_iter_t), intent(inout) :: iter
     class(fhash_key_t), intent(out), allocatable :: key
@@ -67,6 +72,16 @@ module fhash_tbl_iter
     end if
 
   end function fhash_iter_next
+
+
+  !> Reset iterator to beginning
+  subroutine fhash_iter_reset(iter)
+    class(fhash_iter_t), intent(inout) :: iter
+
+    iter%bucket = 1
+    iter%depth = 1
+
+  end subroutine fhash_iter_reset
 
 
 end module fhash_tbl_iter

--- a/src/fhash_tbl_iter.f90
+++ b/src/fhash_tbl_iter.f90
@@ -1,0 +1,72 @@
+module fhash_tbl_iter
+  use fhash_tbl, only: fhash_tbl_t
+  use fhash_key_base, only: fhash_key_t
+  use fhash_data_container, only: fhash_container_t
+  use fhash_sll
+  implicit none
+
+  private
+  public fhash_iter_t
+
+  type fhash_iter_t
+
+    type(fhash_tbl_t), pointer :: tbl => NULL()
+
+    integer :: bucket = 1
+    integer :: depth = 1
+
+  contains
+    procedure :: next => fhash_iter_next
+  end type fhash_iter_t
+
+  interface fhash_iter_t
+    module procedure :: fhash_iter_init
+  end interface fhash_iter_t
+
+  contains
+
+  function fhash_iter_init(tbl) result(iter)
+    type(fhash_tbl_t), intent(in), target :: tbl
+    type(fhash_iter_t) :: iter
+
+    iter%tbl => tbl
+
+  end function fhash_iter_init
+
+    
+  function fhash_iter_next(iter,key,data) result(found)
+    class(fhash_iter_t), intent(inout) :: iter
+    class(fhash_key_t), intent(out), allocatable :: key
+    class(*), allocatable, intent(out) :: data
+    logical :: found
+    
+    type(fhash_container_t), pointer :: data_container
+    class(*), pointer :: data_out
+    
+    found = .false.
+
+    if (.not.associated(iter%tbl)) return
+
+    do while (.not.found)
+      if (iter%bucket > size(iter%tbl%buckets)) return
+      if (.not.allocated(iter%tbl%buckets(iter%bucket)%key)) then
+        iter%bucket = iter%bucket + 1
+        cycle
+      end if
+      call sll_get_at(iter%tbl%buckets(iter%bucket),iter%depth,key,data_container,found)
+      if (iter%depth > node_depth(iter%tbl%buckets(iter%bucket))) then
+        iter%bucket = iter%bucket + 1
+        iter%depth = 1
+      else
+        iter%depth = iter%depth + 1
+      end if
+    end do
+
+    if (found) then
+      call data_container%get(raw=data)  ! Extract underlying polymorphic data
+    end if
+
+  end function fhash_iter_next
+
+
+end module fhash_tbl_iter

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(TestLite TestLite.f90 TestLite_suite.f90 TestLite_error.f90)
 target_include_directories(TestLite PUBLIC
   $<BUILD_INTERFACE:${CMAKE_Fortran_MODULE_DIRECTORY}>)
 
-add_library(tests test_container.f90 test_fnv.f90 test_key.f90 test_sll.f90 test_tbl.f90)
+add_library(tests test_container.f90 test_fnv.f90 test_key.f90 test_sll.f90 test_tbl.f90 test_tbl_iter.f90)
 target_link_libraries(tests fhash TestLite)
 
 

--- a/test/main.f90
+++ b/test/main.f90
@@ -8,6 +8,7 @@ program test
   use test_container, only: collect_container
   use test_sll, only: collect_sll
   use test_tbl, only: collect_tbl
+  use test_tbl_iter, only: collect_tbl_iter
   implicit none
 
   type(testsuite_t), allocatable :: testsuite(:)
@@ -17,7 +18,8 @@ program test
       & new_testsuite("fhash_key", collect_key), &
       & new_testsuite("fhash_container", collect_container), &
       & new_testsuite("fhash_sll", collect_sll), &
-      & new_testsuite("fhash_tbl", collect_tbl) &
+      & new_testsuite("fhash_tbl", collect_tbl), &
+      & new_testsuite("fhash_tbl_iter", collect_tbl_iter) &
   ]
 
   call run_tests(testsuite)

--- a/test/test_tbl_iter.f90
+++ b/test/test_tbl_iter.f90
@@ -1,0 +1,128 @@
+module test_tbl_iter
+    use iso_fortran_env, only: sp=>real32, dp=>real64, int32, int64
+    use TestLite_suite, only : new_unittest, unittest_t, error_t, test_failed
+    use fhash, only: fhash_key_t, key=>fhash_key, fhash_tbl_t, fhash_iter_t
+    implicit none
+  
+    private
+    public collect_tbl_iter
+  
+    contains
+  
+    !> Collect all exported unit tests
+    subroutine collect_tbl_iter(testsuite)
+  
+      !> Collection of tests
+      type(unittest_t), allocatable, intent(out) :: testsuite(:)
+      
+      testsuite = [ &
+          & new_unittest("fhash-iter-intrinsics", test_iter_intrinsics) &
+          ]
+          
+    end subroutine collect_tbl_iter
+  
+    !>  Test intrinsic set and retrieve
+    subroutine test_iter_intrinsics(error)
+      type(error_t), allocatable, intent(out) :: error
+  
+      type(fhash_tbl_t) :: tbl
+      integer(int32) :: set_int32, get_int32
+      integer(int64) :: set_int64, get_int64
+      real(sp) :: set_float, get_float
+      real(dp) :: set_double, get_double
+      character(:), allocatable :: set_char, get_char
+      logical :: set_bool, get_bool
+      
+      integer :: count
+      type(fhash_iter_t) :: iter
+      class(fhash_key_t), allocatable :: ikey
+      class(*), allocatable :: idata
+
+      ! Set values
+      call tbl%set(key('int32'),123_int32)
+      call tbl%set(key('int64'),456_int64)
+      call tbl%set(key('float'),1.0_sp)
+      call tbl%set(key('double'),2.0_dp)
+      call tbl%set(key('char'),'Hello world')
+      call tbl%set(key('bool'),.false.)
+      
+      ! Iterate over stored keys and check values
+      count = 0
+      iter = fhash_iter_t(tbl)
+      do while(iter%next(ikey,idata))
+
+        count = count + 1
+
+        select type(d=>idata)
+        type is(integer(int32))
+          if (ikey%to_string() /= 'int32') then
+            call test_failed(error,'int32 key has incorrect value')
+            return
+          end if
+          if (d /= 123_int32) then
+            call test_failed(error,'int32 data has incorrect value')
+            return
+          end if
+
+        type is(integer(int64))
+          if (ikey%to_string() /= 'int64') then
+            call test_failed(error,'int64 key has incorrect value')
+            return
+          end if
+          if (d /= 456_int64) then
+            call test_failed(error,'int64 data has incorrect value')
+            return
+          end if
+
+        type is(real(sp))
+          if (ikey%to_string() /= 'float') then
+            call test_failed(error,'float key has incorrect value')
+            return
+          end if
+          if (d /= 1.0_sp) then
+            call test_failed(error,'float data has incorrect value')
+            return
+          end if
+
+        type is(real(dp))
+          if (ikey%to_string() /= 'double') then
+            call test_failed(error,'double key has incorrect value')
+            return
+          end if
+          if (d /= 2.0_dp) then
+            call test_failed(error,'double data has incorrect value')
+            return
+          end if
+
+        type is(character(*))
+          if (ikey%to_string() /= 'char') then
+            call test_failed(error,'char key has incorrect value')
+            return
+          end if
+          if (d /= 'Hello world') then
+            call test_failed(error,'char data has incorrect value')
+            return
+          end if
+
+        type is(logical)
+          if (ikey%to_string() /= 'bool') then
+            call test_failed(error,'bool key has incorrect value')
+            return
+          end if
+          if (d) then
+            call test_failed(error,'bool data has incorrect value')
+            return
+          end if
+          
+        end select
+
+      end do
+
+      if (count /= 6) then
+        call test_failed(error,'incorrect number of items iteracted over')
+        return
+      end if
+  
+    end subroutine test_iter_intrinsics
+  
+  end module test_tbl_iter


### PR DESCRIPTION
- Adds an iterator type `fhash_iter_t` for iterating over all items within a hash table
- Adds a to_string deferred method to the key abstract type
- Fixes and simplifications to the CI